### PR TITLE
[build] _CopySourceApk now always runs

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -8,6 +8,7 @@
     <XamarinAndroidLiteFullVersion>$(XamarinAndroidLiteVersion).$(BuildNumber)$(XamarinAndroidLiteSuffix)</XamarinAndroidLiteFullVersion>
     <XamarinFormsVersion>[3.1.0.583944]</XamarinFormsVersion>
     <XamarinEssentialsVersion>[0.8.0-preview]</XamarinEssentialsVersion>
+    <XamarinAndroidReferencePath>$(MSBuildThisFileDirectory)bin\xamarin-android\lib\xamarin.android\xbuild\Xamarin\Android\</XamarinAndroidReferencePath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(IncludePackageReference)' == 'True' ">
     <PackageReference Include="Xamarin.Forms" Version="$(XamarinFormsVersion)" />

--- a/Xamarin.Android.Lite.Tasks/Xamarin.Android.Lite.Tasks.csproj
+++ b/Xamarin.Android.Lite.Tasks/Xamarin.Android.Lite.Tasks.csproj
@@ -5,7 +5,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <BaseOutputPath>..\bin\</BaseOutputPath>
     <OutputPath>$(BaseOutputPath)$(Configuration)\build\</OutputPath>
-    <XamarinAndroidReferencePath>$(BaseOutputPath)xamarin-android\lib\xamarin.android\xbuild\Xamarin\Android\</XamarinAndroidReferencePath>
   </PropertyGroup>
   <Import Project="..\Configuration.props" />
   <!--NuGet settings-->

--- a/Xamarin.Android.Lite.Tasks/Xamarin.Android.Lite.targets
+++ b/Xamarin.Android.Lite.Tasks/Xamarin.Android.Lite.targets
@@ -59,9 +59,8 @@
       <FileWrites Include="$(AndroidManifest)" />
     </ItemGroup>
   </Target>
-  <Target Name="_CopySourceApk" Inputs="$(SourceApkFile)" Outputs="$(AndroidApkFile)">
+  <Target Name="_CopySourceApk">
     <Copy SourceFiles="$(SourceApkFile)" DestinationFiles="$(AndroidApkFile)" SkipUnchangedFiles="True" />
-    <Touch Files="$(AndroidApkFile)" />
     <ItemGroup>
       <FileWrites Include="$(AndroidApkFile)" />
     </ItemGroup>

--- a/Xamarin.Android.Lite.Tests/Xamarin.Android.Lite.Tests.csproj
+++ b/Xamarin.Android.Lite.Tests/Xamarin.Android.Lite.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net462</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
+  <Import Project="..\Configuration.props" />
   <ItemGroup>
     <Content Include="Data\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -18,5 +19,15 @@
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Android.Lite.Sample\Xamarin.Android.Lite.Sample.csproj" />
     <ProjectReference Include="..\Xamarin.Android.Lite.Tasks\Xamarin.Android.Lite.Tasks.csproj" />
+    <Reference Include="$(XamarinAndroidReferencePath)libZipSharp.dll" />
+    <Content Include="$(XamarinAndroidReferencePath)libzip.5.0.dylib" Link="libzip.5.0.dylib">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(XamarinAndroidReferencePath)libzip.dll" Link="libzip.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(XamarinAndroidReferencePath)x64\libzip.dll" Link="x64\libzip.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #4

When I shipped the first update on NuGet, I had to delete bin/obj to see changes in my APK. This was due to `_CopySourceApk` using Inputs/Outputs.

It seems "safer" to use `<Copy SkipUnchangedFiles="True" />` instead of relying on the timestamps from Inputs/Outputs. We don't really care about the timestamps of a file coming from NuGet, and more care about if it is actually different.

I did not see any negative impact to build times here, as the `SkipUnchangedFiles` setting is doing its job.

Tests added:
- Test checking what happens if base APK changes
- Test checking you can modify MSBuild properties that modify `AndroidManifest.xml`

I also moved a property into `Configuration.props` so the tests could reference `LibZipSharp.dll`.